### PR TITLE
Change the Vue import to use 'vue'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ in your tests without having to directly interact with the DOM, and the chai
 plugin can be used to write readable tests with understandable output for
 mounted Vue components.
 
+> NOTE: vue-test requires the **full** version of Vue (which includes the compiler).  Make sure your build configuration for testing aliases `vue` properly.  For example (webpack 2):
+
+```javascript
+{
+  resolve: {
+    alias: {
+      'vue$': 'vue/dist/vue.esm.js'
+    }
+  }
+}
+```
+
 ### The `mount()` function
 
 The `mount()` function takes two arguments, a Vue component, and some optional

--- a/src/MountedComponent.js
+++ b/src/MountedComponent.js
@@ -1,4 +1,6 @@
-import Vue from 'vue/dist/vue.js'; // Use runtime-only build of Vue
+// NOTE: vue-test requires the **Full** version of Vue (which includes the compiler).
+// Make sure your build configuration for testing aliases vue properly.
+import Vue from 'vue';
 import dashify from 'dashify';
 
 import * as attributeFns from './mounted-fns/attributes';


### PR DESCRIPTION
Change the Vue import to use 'vue' instead of 'vue/dist/vue.js' so that multiple copies of Vue aren't pulled into the tests.